### PR TITLE
Feature/manifest filters

### DIFF
--- a/ConfigFiles/manifest.json
+++ b/ConfigFiles/manifest.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
+    "com.unity.feature.2d": "2.0.0",
+    "com.unity.cinemachine": "2.9.5",
+
+    "com.unity.feature.mobile": "1.0.0",
+    "com.unity.services.levelplay": "8.0.0",
+    "com.unity.purchasing": "4.11.0",
+
+    "com.unity.ai.navigation": "1.1.5",
+    "com.unity.memoryprofiler": "1.1.0",
     "com.unity.ide.rider": "3.0.26",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.madsbangh.easybuttons": "https://github.com/madsbangh/EasyButtons.git#upm",
@@ -11,9 +20,9 @@
     "com.unity.feature.development": "1.0.1",
     "com.unity.feature.gameplay-storytelling": "1.0.0",
     "com.unity.feature.worldbuilding": "1.0.1",
-    "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.7.0",
     "com.unity.localization": "1.4.5",
+    "com.unity.serialization": "3.1.1",
     "com.unity.recorder": "4.0.2",
     "com.unity.postprocessing": "3.2.2",
     "com.unity.profiling.core": "1.0.2",
@@ -26,7 +35,7 @@
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualeffectgraph": "12.1.10",
-    "com.unity.visualscripting": "1.9.2",
+    "com.unity.visualscripting": "1.9.4",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/ConfigFiles/manifest.json
+++ b/ConfigFiles/manifest.json
@@ -9,7 +9,7 @@
 
     "com.unity.ai.navigation": "1.1.5",
     "com.unity.memoryprofiler": "1.1.0",
-    "com.unity.ide.rider": "3.0.26",
+    "com.unity.ide.rider": "3.0.28",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.madsbangh.easybuttons": "https://github.com/madsbangh/EasyButtons.git#upm",
     "com.unity.addressables": "1.21.20",
@@ -18,6 +18,7 @@
     "com.unity.collections": "2.1.4",
     "com.unity.feature.characters-animation": "1.0.0",
     "com.unity.feature.development": "1.0.1",
+    "com.unity.editorcoroutines": "1.0.0",
     "com.unity.feature.gameplay-storytelling": "1.0.0",
     "com.unity.feature.worldbuilding": "1.0.1",
     "com.unity.inputsystem": "1.7.0",

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ $ git commit -m "First commit: Through unity-sensen-setup init-git"
 
 4. Execute the initial setup
 ```bash
-$ python ./unity-sensen-setup/setup.py init
+$ python ./unity-sensen-setup/setup.py init --2d --mobile --minimal
 # This will:
 # - Import all configurations
 # - Initialize unity-sensen-toolkit submodule
 # - Create the ./PackagesBatch/ folder with DOTWeen inside
+# Valid Options:
+# --2d | --3d | --mobile | --desktop | --minimal
+# See more on manifest filtering section
 ```
 
 4. Open the project on Unity
@@ -106,6 +109,21 @@ For the merging to work you will need to configure the tool, see more on [https:
 2. At the topbar menu execute: `Tools > Sensen > Import Packages Batch`
 3. Press "CTRL + R" (Refresh Assets)
 4. Move the files related to assets to `/Assets/Vendor` (this folder is in `.gitignore`)
+
+### Manifest filtering
+Depending on the project (2d, 3d, mobile, desktop) you'll probably need a different set of
+dependencies. For that reason, all commands that pushed the manifest can receive one of the
+following options:
+* `--2d`: Forces it to add 2D dependencies and exclude 3D-only dependencies
+* `--3d`: Forces it to add 3D dependencies and exclude 2D-only dependencies
+* `--mobile`: Forces it to add mobile-only dependencies
+* `--desktop`: Forces it to exclude mobile-only dependencies
+* `--slim`: Removes dependencies that usually won't be used in prototypes and
+gamejam projects. (eg. localization, analytics, testing, profilling tools, etc)
+
+
+_PS.: If you don't pass any options explicitly the script will try to guess based on the project's
+dependencies._
 
 ## VS Code extra config
 ### Suggested Extensions

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,7 @@
-#!/usr/bin/env python3
-import os
-import glob
-from datetime import datetime
 import argparse
-import shutil
-import subprocess
-from src.manifest import merge_manifests, is_2d_manifest, is_mobile_manifest
-from src.nuget import merge_nuget_packages_config, update_omnisharp_json
-from src.utils import write_unix
 
-SETUP_ROOT = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = os.path.abspath(os.path.join(SETUP_ROOT, '..'))
-BKP_FOLDER = os.path.join(SETUP_ROOT, 'bkp')
-SUBMODULES_FOLDER = os.path.join(PROJECT_ROOT, 'Assets', 'Plugins', 'Submodules')
-DEFAULT_PROJECT_NAME = os.path.basename(PROJECT_ROOT)
-
-OMNISHARP_SETUP_PATH = os.path.join(SETUP_ROOT, 'ConfigFiles', 'omnisharp.json')
-
-MANIFEST_PROJECT_PATH = os.path.join(PROJECT_ROOT, 'Packages', 'manifest.json')
-MANIFEST_SETUP_PATH = os.path.join(SETUP_ROOT, 'ConfigFiles', 'manifest.json')
-NUGET_PROJECT_PATH = os.path.join(PROJECT_ROOT, 'Assets', 'packages.config')
-NUGET_SETUP_PATH = os.path.join(SETUP_ROOT, 'ConfigFiles', 'packages.config')
+from src.SetupExecutor import SetupExecutor, MANIFEST_PROJECT_PATH
+from src.manifest import is_2d_manifest, is_mobile_manifest
 
 COMMAND_INIT_GIT = 'init-git'
 COMMAND_SETUP_INIT = 'init'
@@ -43,220 +24,80 @@ COMMANDS = [
     COMMAND_PUSH_NUGET,
 ]
 
-# BACKUP CONFIG FILES
-def backup_file_if_exists(filename, filefolder='.'):
-    filepath = os.path.join(filefolder, filename)
-    if os.path.isfile(filepath):
-        print(f'Backing up {filename} in bkp/')
-        timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
-        shutil.copy(filepath, os.path.join(BKP_FOLDER, f'{timestamp}_{filename}'))
+if __name__ != '__main__':
+    throw('This script should not be imported')
 
-def backup_config_files():
-    backup_file_if_exists('.gitignore')
-    backup_file_if_exists('.gitattributes')
-    backup_file_if_exists('.editorconfig')
-    backup_file_if_exists('omnisharp.json')
-    backup_file_if_exists('NuGet.config', 'Assets')
-    backup_file_if_exists('packages.config', 'Assets')
-    backup_file_if_exists('manifest.json', 'Packages')
+parser = argparse.ArgumentParser()
+parser.add_argument('command', choices=COMMANDS, default=COMMANDS[0], help='Command to run', type=str)
+parser.add_argument('--name', default=None, help='Name of the game', type=str, required=False)
+parser.add_argument('--2d', dest='two_d', default=False, help='Force to use 2D dependencies', type=bool, required=False)
+parser.add_argument('--3d', dest='three_d', default=False, help='Force to use 3D dependencies', type=bool, required=False)
+parser.add_argument('--mobile', default=False, help='Use mobile dependencies', type=bool, required=False)
+parser.add_argument('--desktop', default=False, help='Use desktop dependencies', type=bool, required=False)
+parser.add_argument('--minimal', default=False, help='Remove some optional dependencies', type=bool, required=False)
+args = parser.parse_args()
 
-def init_git():
-    __replace_config('.gitignore', './')
-    __replace_config('gitattributes', './.gitattributes')
-    subprocess.run(['git', 'init'], cwd=PROJECT_ROOT)
-    subprocess.run(['git', 'lfs', 'install'], cwd=PROJECT_ROOT)
+if args.two_d and args.three_d:
+    print('Cannot use 2D and 3D at the same time')
+    exit(1)
 
-def import_configs():
-    push_nuget()
-    __replace_config('.editorconfig', '.')
-    __copy_all_files('PackagesBatch/*.unitypackage', './PackagesBatch/')
-
-def create_project_structure():
-    project_structure_path = os.path.join(PROJECT_ROOT, 'Assets', args.name)
-    if os.path.exists(project_structure_path):
-        print(f'!!! Project structure folder already exists: {project_structure_path}')
-    else:
-        shutil.copytree(os.path.join(SETUP_ROOT, 'Templates/ProjectStructure/'), project_structure_path)
-    __ensure_folder('Assets/Vendor')
-    __ensure_folder('Assets/Plugins/_Ignore')
-
-def init_submodules(only_toolkit=False):
-    os.makedirs(SUBMODULES_FOLDER, exist_ok=True)
-    subprocess.run(['git', 'submodule', 'init'], cwd=PROJECT_ROOT)
-    if not only_toolkit:
-        __add_submodule('dev', 'https://github.com/HugoLnx/unity-lnx-arch.git', 'unity-lnx-arch')
-        __add_submodule('dev', 'https://github.com/HugoLnx/unity-sensen-components.git', 'unity-sensen-components')
-    __add_submodule('dev', 'https://github.com/HugoLnx/unity-sensen-toolkit.git', 'unity-sensen-toolkit')
-    subprocess.run(['git', 'submodule', 'update', '--recursive', '--remote'], cwd=PROJECT_ROOT)
-
-def cleanup_submodules():
-    subprocess.run(['git', 'submodule', 'deinit', '-f', '.'], cwd=PROJECT_ROOT)
-    shutil.rmtree(SUBMODULES_FOLDER, ignore_errors=True)
-
-def pull_manifest():
-    result = merge_manifests(
-        source_path=MANIFEST_PROJECT_PATH,
-        target_path=MANIFEST_SETUP_PATH,
-        add_new_dependencies=False
-    )
-    new_manifest = result['new_manifest']
-    new_dependencies_snippet = result['new_dependencies_snippet']
-    version_updates_snippet = result['version_updates_snippet']
-
-    if version_updates_snippet is not None:
-        write_unix(MANIFEST_SETUP_PATH, new_manifest)
-        print('Updated setup base manifest...')
-        print(version_updates_snippet)
-    else:
-        print('Setup manifest has no versions to update')
-
-    if new_dependencies_snippet is not None:
-        print('> Project manifest has dependencies that are not in source manifest...')
-        print(new_dependencies_snippet)
-        print('Consider adding them manually to the setup manifest')
-
-def push_manifest(manifest_filters):
-    result = merge_manifests(
-        source_path=MANIFEST_SETUP_PATH,
-        target_path=MANIFEST_PROJECT_PATH,
-        add_new_dependencies=True,
-        filters=manifest_filters
-    )
-    new_manifest = result['new_manifest']
-    new_dependencies_snippet = result['new_dependencies_snippet']
-    version_updates_snippet = result['version_updates_snippet']
-    removed_dependencies = result['removed_dependencies']
-
-    has_updates = version_updates_snippet is not None \
-        or new_dependencies_snippet is not None \
-        or len(removed_dependencies) > 0
-
-    if has_updates:
-        write_unix(MANIFEST_PROJECT_PATH, new_manifest)
-        print('> Updated project manifest...')
-        print(version_updates_snippet)
-    else:
-        print('Project manifest is already up-to-date')
-
-    if new_dependencies_snippet is not None:
-        print('> Added new dependencies to project manifest')
-        print(new_dependencies_snippet)
-
-    if len(removed_dependencies) > 0:
-        print('> Removed dependencies from project manifest')
-        print('\n'.join(removed_dependencies))
-
-def pull_nuget():
-    (new_content, packages) = merge_nuget_packages_config(
-        source_path=NUGET_PROJECT_PATH,
-        target_path=NUGET_SETUP_PATH,
-    )
-
-    write_unix(NUGET_SETUP_PATH, new_content)
-
-    new_json_content = update_omnisharp_json(OMNISHARP_SETUP_PATH, packages)
-    write_unix(OMNISHARP_SETUP_PATH, new_json_content)
-
-def push_nuget():
-    __replace_config('omnisharp.json', '.')
-    __replace_config('NuGet.config', 'Assets')
-    __replace_config('packages.config', 'Assets')
+if args.mobile and args.desktop:
+    print('Cannot use mobile and desktop at the same time')
+    print('PS.: If you are making a cross-platform game, just use --mobile to add the mobile dependencies')
+    exit(1)
 
 
-def __add_submodule(branch_name, git_url, folder_name):
-    folder_path = os.path.join(SUBMODULES_FOLDER, folder_name)
-    folder_relpath = os.path.relpath(folder_path, PROJECT_ROOT)
-    cmd = ['git', 'submodule', 'add', '-f', '-b', branch_name, '--', git_url, folder_relpath]
-    subprocess.run(cmd, cwd=PROJECT_ROOT)
+is_2d = args.two_d or (not(args.three_d) and is_2d_manifest(MANIFEST_PROJECT_PATH))
+is_3d = not is_2d
+is_mobile = args.mobile or (not(args.desktop) and is_mobile_manifest(MANIFEST_PROJECT_PATH))
+is_minimal = args.minimal
 
-def __replace_config(config_relative_path, target_relative_path):
-    config_path = os.path.join(SETUP_ROOT, 'ConfigFiles', config_relative_path)
-    target_path = os.path.join(PROJECT_ROOT, target_relative_path)
-    shutil.copy(config_path, target_path)
+was_auto_detected = not(args.two_d) and not(args.three_d)
+print(f'Using {'2D' if is_2d else '3D'}{' mobile' if is_mobile else ''}{' minimal' if is_minimal else ''} dependencies {'(Auto-detected)' if was_auto_detected else ''}')
 
-def __copy_all_files(source_folder, target_folder):
-    source_path = os.path.join(SETUP_ROOT, source_folder)
-    target_path = os.path.abspath(os.path.join(PROJECT_ROOT, target_folder))
-    os.makedirs(target_path, exist_ok=True)
+manifest_filters = {
+    '2d': is_2d,
+    '3d': is_3d,
+    'mobile': is_mobile,
+    'minimal': is_minimal,
+}
 
-    source_files = glob.glob(source_path)
-    for source_file in source_files:
-        if os.path.isfile(source_file):
-            shutil.copy(source_file, target_path)
-            print(f'Copied {source_file} to {target_path}')
+if args.command not in COMMANDS:
+    print(f'Invalid command: {args.command}')
+    print(f'Valid commands: {COMMANDS}')
+    exit(1)
 
-def __ensure_folder(folder_relative_path):
-    folder_path = os.path.join(PROJECT_ROOT, folder_relative_path)
-    os.makedirs(folder_path, exist_ok=True)
-    open(os.path.join(folder_path, '.gitkeep'), 'a').close()
+e = SetupExecutor(
+    project_name=args.name,
+    manifest_filters=manifest_filters,
+)
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument('command', choices=COMMANDS, default=COMMANDS[0], help='Command to run', type=str)
-    parser.add_argument('--name', default=DEFAULT_PROJECT_NAME, help='Name of the game', type=str, required=False)
-    parser.add_argument('--2d', dest='two_d', default=False, help='Force to use 2D dependencies', type=bool, required=False)
-    parser.add_argument('--3d', dest='three_d', default=False, help='Force to use 3D dependencies', type=bool, required=False)
-    parser.add_argument('--mobile', default=False, help='Use mobile dependencies', type=bool, required=False)
-    parser.add_argument('--desktop', default=False, help='Use desktop dependencies', type=bool, required=False)
-    parser.add_argument('--minimal', default=False, help='Remove some optional dependencies', type=bool, required=False)
-    args = parser.parse_args()
-
-    if args.two_d and args.three_d:
-        print('Cannot use 2D and 3D at the same time')
-        exit(1)
-
-    if args.mobile and args.desktop:
-        print('Cannot use mobile and desktop at the same time')
-        print('PS.: If you are making a cross-platform game, just use --mobile to add the mobile dependencies')
-        exit(1)
-
-
-    is_2d = args.two_d or (not(args.three_d) and is_2d_manifest(MANIFEST_PROJECT_PATH))
-    is_3d = not is_2d
-    is_mobile = args.mobile or (not(args.desktop) and is_mobile_manifest(MANIFEST_PROJECT_PATH))
-    is_minimal = args.minimal
-
-    was_auto_detected = not(args.two_d) and not(args.three_d)
-    print(f'Using {'2D' if is_2d else '3D'}{' mobile' if is_mobile else ''}{' minimal' if is_minimal else ''} dependencies {'(Auto-detected)' if was_auto_detected else ''}')
-
-    manifest_filters = {
-        '2d': is_2d,
-        '3d': is_3d,
-        'mobile': is_mobile,
-        'minimal': is_minimal,
-    }
-
-    if args.command not in COMMANDS:
-        print(f'Invalid command: {args.command}')
-        print(f'Valid commands: {COMMANDS}')
-        exit(1)
-
-    if args.command == COMMAND_INIT_GIT:
-        backup_config_files()
-        init_git()
-    elif args.command == COMMAND_SETUP_INIT:
-        backup_config_files()
-        init_git()
-        push_manifest(manifest_filters)
-        import_configs()
-        init_submodules(only_toolkit=True)
-    elif args.command == COMMAND_SETUP_ALL:
-        backup_config_files()
-        init_git()
-        push_manifest(manifest_filters)
-        import_configs()
-        create_project_structure()
-        init_submodules()
-    elif args.command == COMMAND_INIT_SUBMODULES:
-        init_git()
-        init_submodules()
-    elif args.command == COMMAND_RM_SUBMODULES:
-        cleanup_submodules()
-    elif args.command == COMMAND_PULL_MANIFEST:
-        pull_manifest()
-    elif args.command == COMMAND_PUSH_MANIFEST:
-        push_manifest(manifest_filters)
-    elif args.command == COMMAND_PULL_NUGET:
-        pull_nuget()
-    elif args.command == COMMAND_PUSH_NUGET:
-        push_nuget()
+if args.command == COMMAND_INIT_GIT:
+    e.backup_config_files()
+    e.init_git()
+elif args.command == COMMAND_SETUP_INIT:
+    e.backup_config_files()
+    e.init_git()
+    e.push_manifest()
+    e.import_configs()
+    e.init_submodules(only_toolkit=True)
+elif args.command == COMMAND_SETUP_ALL:
+    e.backup_config_files()
+    e.init_git()
+    e.push_manifest()
+    e.import_configs()
+    e.create_project_structure()
+    e.init_submodules()
+elif args.command == COMMAND_INIT_SUBMODULES:
+    e.init_git()
+    e.init_submodules()
+elif args.command == COMMAND_RM_SUBMODULES:
+    e.cleanup_submodules()
+elif args.command == COMMAND_PULL_MANIFEST:
+    e.pull_manifest()
+elif args.command == COMMAND_PUSH_MANIFEST:
+    e.push_manifest()
+elif args.command == COMMAND_PULL_NUGET:
+    e.pull_nuget()
+elif args.command == COMMAND_PUSH_NUGET:
+    e.push_nuget()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ parser.add_argument('--2d', dest='two_d', default=False, help='Force to use 2D d
 parser.add_argument('--3d', dest='three_d', default=False, help='Force to use 3D dependencies', action='store_true', required=False)
 parser.add_argument('--mobile', default=False, help='Use mobile dependencies', action='store_true', required=False)
 parser.add_argument('--desktop', default=False, help='Use desktop dependencies', action='store_true', required=False)
-parser.add_argument('--minimal', default=False, help='Remove some optional dependencies', action='store_true', required=False)
+parser.add_argument('--slim', default=False, help='Remove some optional dependencies (good for prototypes and gamejams)', action='store_true', required=False)
 args = parser.parse_args()
 
 if args.two_d and args.three_d:
@@ -50,16 +50,16 @@ if args.mobile and args.desktop:
 is_2d = args.two_d or (not(args.three_d) and is_2d_manifest(MANIFEST_PROJECT_PATH))
 is_3d = not is_2d
 is_mobile = args.mobile or (not(args.desktop) and is_mobile_manifest(MANIFEST_PROJECT_PATH))
-is_minimal = args.minimal
+is_slim = args.slim
 
 was_auto_detected = not(args.two_d) and not(args.three_d)
-print(f'Using {'2D' if is_2d else '3D'}{' mobile' if is_mobile else ''}{' minimal' if is_minimal else ''} dependencies {'(Auto-detected)' if was_auto_detected else ''}')
+print(f'Using {'2D' if is_2d else '3D'}{' mobile' if is_mobile else ''}{' slim' if is_slim else ''} dependencies {'(Auto-detected)' if was_auto_detected else ''}')
 
 manifest_filters = {
     '2d': is_2d,
     '3d': is_3d,
     'mobile': is_mobile,
-    'minimal': is_minimal,
+    'slim': is_slim,
 }
 
 if args.command not in COMMANDS:

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,11 @@ if __name__ != '__main__':
 parser = argparse.ArgumentParser()
 parser.add_argument('command', choices=COMMANDS, default=COMMANDS[0], help='Command to run', type=str)
 parser.add_argument('--name', default=None, help='Name of the game', type=str, required=False)
-parser.add_argument('--2d', dest='two_d', default=False, help='Force to use 2D dependencies', type=bool, required=False)
-parser.add_argument('--3d', dest='three_d', default=False, help='Force to use 3D dependencies', type=bool, required=False)
-parser.add_argument('--mobile', default=False, help='Use mobile dependencies', type=bool, required=False)
-parser.add_argument('--desktop', default=False, help='Use desktop dependencies', type=bool, required=False)
-parser.add_argument('--minimal', default=False, help='Remove some optional dependencies', type=bool, required=False)
+parser.add_argument('--2d', dest='two_d', default=False, help='Force to use 2D dependencies', action='store_true', required=False)
+parser.add_argument('--3d', dest='three_d', default=False, help='Force to use 3D dependencies', action='store_true', required=False)
+parser.add_argument('--mobile', default=False, help='Use mobile dependencies', action='store_true', required=False)
+parser.add_argument('--desktop', default=False, help='Use desktop dependencies', action='store_true', required=False)
+parser.add_argument('--minimal', default=False, help='Remove some optional dependencies', action='store_true', required=False)
 args = parser.parse_args()
 
 if args.two_d and args.three_d:

--- a/src/SetupExecutor.py
+++ b/src/SetupExecutor.py
@@ -1,0 +1,172 @@
+import os
+import glob
+from datetime import datetime
+import shutil
+import subprocess
+from src.manifest import merge_manifests
+from src.nuget import merge_nuget_packages_config, update_omnisharp_json
+from src.utils import write_unix
+
+SETUP_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+PROJECT_ROOT = os.path.abspath(os.path.join(SETUP_ROOT, '..'))
+BKP_FOLDER = os.path.join(SETUP_ROOT, 'bkp')
+SUBMODULES_FOLDER = os.path.join(PROJECT_ROOT, 'Assets', 'Plugins', 'Submodules')
+DEFAULT_PROJECT_NAME = os.path.basename(PROJECT_ROOT)
+
+OMNISHARP_SETUP_PATH = os.path.join(SETUP_ROOT, 'ConfigFiles', 'omnisharp.json')
+
+MANIFEST_PROJECT_PATH = os.path.join(PROJECT_ROOT, 'Packages', 'manifest.json')
+MANIFEST_SETUP_PATH = os.path.join(SETUP_ROOT, 'ConfigFiles', 'manifest.json')
+NUGET_PROJECT_PATH = os.path.join(PROJECT_ROOT, 'Assets', 'packages.config')
+NUGET_SETUP_PATH = os.path.join(SETUP_ROOT, 'ConfigFiles', 'packages.config')
+
+class SetupExecutor:
+    def __init__(self, project_name, manifest_filters):
+        self.project_name = project_name or DEFAULT_PROJECT_NAME
+        self.manifest_filters = manifest_filters
+
+    def backup_config_files(self):
+        self.__backup_file_if_exists('.gitignore')
+        self.__backup_file_if_exists('.gitattributes')
+        self.__backup_file_if_exists('.editorconfig')
+        self.__backup_file_if_exists('omnisharp.json')
+        self.__backup_file_if_exists('NuGet.config', 'Assets')
+        self.__backup_file_if_exists('packages.config', 'Assets')
+        self.__backup_file_if_exists('manifest.json', 'Packages')
+
+    def init_git(self):
+        self.__replace_config('.gitignore', './')
+        self.__replace_config('gitattributes', './.gitattributes')
+        subprocess.run(['git', 'init'], cwd=PROJECT_ROOT)
+        subprocess.run(['git', 'lfs', 'install'], cwd=PROJECT_ROOT)
+
+    def import_configs(self):
+        self.push_nuget()
+        self.__replace_config('.editorconfig', '.')
+        self.__copy_all_files('PackagesBatch/*.unitypackage', './PackagesBatch/')
+
+    def create_project_structure(self):
+        project_structure_path = os.path.join(PROJECT_ROOT, 'Assets', self.project_name)
+        if os.path.exists(project_structure_path):
+            print(f'!!! Project structure folder already exists: {project_structure_path}')
+        else:
+            shutil.copytree(os.path.join(SETUP_ROOT, 'Templates/ProjectStructure/'), project_structure_path)
+        self.__ensure_folder('Assets/Vendor')
+        self.__ensure_folder('Assets/Plugins/_Ignore')
+
+    def init_submodules(self, only_toolkit=False):
+        os.makedirs(SUBMODULES_FOLDER, exist_ok=True)
+        subprocess.run(['git', 'submodule', 'init'], cwd=PROJECT_ROOT)
+        if not only_toolkit:
+            self.__add_submodule('dev', 'https://github.com/HugoLnx/unity-lnx-arch.git', 'unity-lnx-arch')
+            self.__add_submodule('dev', 'https://github.com/HugoLnx/unity-sensen-components.git', 'unity-sensen-components')
+        self.__add_submodule('dev', 'https://github.com/HugoLnx/unity-sensen-toolkit.git', 'unity-sensen-toolkit')
+        subprocess.run(['git', 'submodule', 'update', '--recursive', '--remote'], cwd=PROJECT_ROOT)
+
+    def cleanup_submodules(self):
+        subprocess.run(['git', 'submodule', 'deinit', '-f', '.'], cwd=PROJECT_ROOT)
+        shutil.rmtree(SUBMODULES_FOLDER, ignore_errors=True)
+
+    def pull_manifest(self):
+        result = merge_manifests(
+            source_path=MANIFEST_PROJECT_PATH,
+            target_path=MANIFEST_SETUP_PATH,
+            add_new_dependencies=False
+        )
+        new_manifest = result['new_manifest']
+        new_dependencies_snippet = result['new_dependencies_snippet']
+        version_updates_snippet = result['version_updates_snippet']
+
+        if version_updates_snippet is not None:
+            write_unix(MANIFEST_SETUP_PATH, new_manifest)
+            print('Updated setup base manifest...')
+            print(version_updates_snippet)
+        else:
+            print('Setup manifest has no versions to update')
+
+        if new_dependencies_snippet is not None:
+            print('> Project manifest has dependencies that are not in source manifest...')
+            print(new_dependencies_snippet)
+            print('Consider adding them manually to the setup manifest')
+
+    def push_manifest(self):
+        result = merge_manifests(
+            source_path=MANIFEST_SETUP_PATH,
+            target_path=MANIFEST_PROJECT_PATH,
+            add_new_dependencies=True,
+            filters=self.manifest_filters
+        )
+        new_manifest = result['new_manifest']
+        new_dependencies_snippet = result['new_dependencies_snippet']
+        version_updates_snippet = result['version_updates_snippet']
+        removed_dependencies = result['removed_dependencies']
+
+        has_updates = version_updates_snippet is not None \
+            or new_dependencies_snippet is not None \
+            or len(removed_dependencies) > 0
+
+        if has_updates:
+            write_unix(MANIFEST_PROJECT_PATH, new_manifest)
+            print('> Updated project manifest...')
+            print(version_updates_snippet)
+        else:
+            print('Project manifest is already up-to-date')
+
+        if new_dependencies_snippet is not None:
+            print('> Added new dependencies to project manifest')
+            print(new_dependencies_snippet)
+
+        if len(removed_dependencies) > 0:
+            print('> Removed dependencies from project manifest')
+            print('\n'.join(removed_dependencies))
+
+    def pull_nuget(self):
+        (new_content, packages) = merge_nuget_packages_config(
+            source_path=NUGET_PROJECT_PATH,
+            target_path=NUGET_SETUP_PATH,
+        )
+
+        write_unix(NUGET_SETUP_PATH, new_content)
+
+        new_json_content = update_omnisharp_json(OMNISHARP_SETUP_PATH, packages)
+        write_unix(OMNISHARP_SETUP_PATH, new_json_content)
+
+    def push_nuget(self):
+        self.__replace_config('omnisharp.json', '.')
+        self.__replace_config('NuGet.config', 'Assets')
+        self.__replace_config('packages.config', 'Assets')
+
+
+    def __add_submodule(self, branch_name, git_url, folder_name):
+        folder_path = os.path.join(SUBMODULES_FOLDER, folder_name)
+        folder_relpath = os.path.relpath(folder_path, PROJECT_ROOT)
+        cmd = ['git', 'submodule', 'add', '-f', '-b', branch_name, '--', git_url, folder_relpath]
+        subprocess.run(cmd, cwd=PROJECT_ROOT)
+
+    def __replace_config(self, config_relative_path, target_relative_path):
+        config_path = os.path.join(SETUP_ROOT, 'ConfigFiles', config_relative_path)
+        target_path = os.path.join(PROJECT_ROOT, target_relative_path)
+        shutil.copy(config_path, target_path)
+
+    def __copy_all_files(self, source_folder, target_folder):
+        source_path = os.path.join(SETUP_ROOT, source_folder)
+        target_path = os.path.abspath(os.path.join(PROJECT_ROOT, target_folder))
+        os.makedirs(target_path, exist_ok=True)
+
+        source_files = glob.glob(source_path)
+        for source_file in source_files:
+            if os.path.isfile(source_file):
+                shutil.copy(source_file, target_path)
+                print(f'Copied {source_file} to {target_path}')
+
+    def __ensure_folder(self, folder_relative_path):
+        folder_path = os.path.join(PROJECT_ROOT, folder_relative_path)
+        os.makedirs(folder_path, exist_ok=True)
+        open(os.path.join(folder_path, '.gitkeep'), 'a').close()
+
+    def __backup_file_if_exists(self, filename, filefolder='.'):
+        filepath = os.path.join(filefolder, filename)
+        if os.path.isfile(filepath):
+            print(f'Backing up {filename} in bkp/')
+            timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+            shutil.copy(filepath, os.path.join(BKP_FOLDER, f'{timestamp}_{filename}'))

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -66,7 +66,6 @@ def merge_manifests(target_path, source_path, add_new_dependencies=True, filters
     target_dependencies = target_json['dependencies']
     source_dependencies = source_json['dependencies']
     dependencies_to_remove = __dependencies_to_remove(filters)
-    print(f'Dependencies to remove: {dependencies_to_remove}')
 
     # update versions in target
     version_updates = []

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -38,17 +38,19 @@ IDENTIFIER_MOBILE_DEPENDENCIES = DEPENDENCIES_MOBILE_ONLY.union(set([
 ]))
 
 REMOVE_ON_MINIMAL = set([
+    'com.unity.feature.development',
+    'com.unity.test-framework',
+    'com.unity.memoryprofiler',
+    'com.unity.recorder',
+    'com.unity.testtools.codecoverage',
+    'com.unity.performance.profile-analyzer',
     'com.unity.collections',
     'com.unity.localization',
-    'com.unity.recorder',
-    'com.unity.test-framework',
     'com.unity.services.analytics',
     'com.unity.timeline',
     'com.unity.visualscripting',
     'com.unity.collab-proxy',
-    'com.unity.ide.rider',
     'com.unity.addressables',
-    'com.unity.memoryprofiler',
 ])
 
 ALWAYS_REMOVE = [

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -37,7 +37,7 @@ IDENTIFIER_MOBILE_DEPENDENCIES = DEPENDENCIES_MOBILE_ONLY.union(set([
     'com.unity.mobile.notifications',
 ]))
 
-REMOVE_ON_MINIMAL = set([
+REMOVE_ON_SLIM = set([
     'com.unity.feature.development',
     'com.unity.test-framework',
     'com.unity.memoryprofiler',
@@ -129,7 +129,7 @@ def is_mobile_manifest(manifest_path):
 def __dependencies_to_remove(filters = {}):
     is_2d = filters.get('2d', False)
     is_3d = filters.get('3d', False)
-    is_minimal = filters.get('minimal', False)
+    is_slim = filters.get('slim', False)
     is_mobile = filters.get('mobile', False)
     if not is_2d and not is_3d:
         is_3d = True
@@ -143,8 +143,8 @@ def __dependencies_to_remove(filters = {}):
     else:
         to_remove += DEPENDENCIES_2D_ONLY
 
-    if is_minimal:
-        to_remove += REMOVE_ON_MINIMAL
+    if is_slim:
+        to_remove += REMOVE_ON_SLIM
     if not is_mobile:
         to_remove += DEPENDENCIES_MOBILE_ONLY
 

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -3,7 +3,59 @@ import os
 import re
 from .utils import is_version_higher_than, write_unix
 
-def merge_manifests(target_path, source_path, add_new_dependencies=True):
+DEPENDENCIES_2D_ONLY = set([
+    'com.unity.feature.2d',
+    'com.unity.cinemachine',
+])
+
+IDENTIFIER_2D_DEPENDENCIES = set([
+    'com.unity.feature.2d',
+    'com.unity.2d.animation',
+    'com.unity.2d.pixel-perfect',
+    'com.unity.2d.sprite',
+    'com.unity.2d.spriteshape',
+    'com.unity.2d.tilemap',
+    'com.unity.2d.tilemap.extras',
+])
+
+DEPENDENCIES_3D_ONLY = set([
+    'com.unity.feature.characters-animation',
+    'com.unity.feature.worldbuilding',
+    'com.unity.progrids',
+    'com.unity.ai.navigation',
+])
+
+DEPENDENCIES_MOBILE_ONLY = set([
+    'com.unity.feature.mobile',
+    'com.unity.services.levelplay',
+    'com.unity.purchasing',
+])
+
+IDENTIFIER_MOBILE_DEPENDENCIES = DEPENDENCIES_MOBILE_ONLY.union(set([
+    'com.unity.mobile.android-logcat',
+    'com.unity.adaptiveperformance',
+    'com.unity.mobile.notifications',
+]))
+
+REMOVE_ON_MINIMAL = set([
+    'com.unity.collections',
+    'com.unity.localization',
+    'com.unity.recorder',
+    'com.unity.test-framework',
+    'com.unity.services.analytics',
+    'com.unity.timeline',
+    'com.unity.visualscripting',
+    'com.unity.collab-proxy',
+    'com.unity.ide.rider',
+    'com.unity.addressables',
+    'com.unity.memoryprofiler',
+])
+
+ALWAYS_REMOVE = [
+    'com.unity.ide.vscode',
+]
+
+def merge_manifests(target_path, source_path, add_new_dependencies=True, filters={}):
     with open(target_path, 'r') as manifest_file:
         target_manifest_str = manifest_file.read()
 
@@ -13,6 +65,8 @@ def merge_manifests(target_path, source_path, add_new_dependencies=True):
     target_json = json.loads(target_manifest_str)
     target_dependencies = target_json['dependencies']
     source_dependencies = source_json['dependencies']
+    dependencies_to_remove = __dependencies_to_remove(filters)
+    print(f'Dependencies to remove: {dependencies_to_remove}')
 
     # update versions in target
     version_updates = []
@@ -28,8 +82,16 @@ def merge_manifests(target_path, source_path, add_new_dependencies=True):
         dependency_pattern = r'"' + re.escape(key) + r'"\s*:\s*"[^"]+"'
         target_manifest_str = re.sub(dependency_pattern, f'"{key}": "{version}"', target_manifest_str)
 
+    removed_dependencies = []
+    for key in dependencies_to_remove:
+        dependency_pattern = r'[^\n]*"' + re.escape(key) + r'"[^\n]*\n'
+        if re.search(dependency_pattern, target_manifest_str):
+            removed_dependencies.append(key)
+        target_manifest_str = re.sub(dependency_pattern, '', target_manifest_str)
+
     # generates new dependency lines
     only_in_source = source_dependencies.keys() - target_dependencies.keys()
+    only_in_source -= dependencies_to_remove
     if len(only_in_source) == 0:
         new_dependencies_lines = None
     else:
@@ -43,4 +105,48 @@ def merge_manifests(target_path, source_path, add_new_dependencies=True):
             target_manifest_str = re.sub(r'("dependencies".*:[^\n]+)', f"\\1{new_dependencies_lines}", target_manifest_str)
 
     version_updates_lines = '\n'.join(version_updates) if len(version_updates) > 0 else None
-    return (target_manifest_str, new_dependencies_lines, version_updates_lines)
+
+    return {
+        'new_manifest': target_manifest_str,
+        'new_dependencies_snippet': new_dependencies_lines,
+        'version_updates_snippet': version_updates_lines,
+        'removed_dependencies': removed_dependencies,
+    }
+
+def is_2d_manifest(manifest_path):
+    with open(manifest_path, 'r') as manifest_file:
+        manifest_content = manifest_file.read()
+
+    return any([dep in manifest_content for dep in IDENTIFIER_2D_DEPENDENCIES])
+
+def is_mobile_manifest(manifest_path):
+    with open(manifest_path, 'r') as manifest_file:
+        manifest_content = manifest_file.read()
+
+    return any([dep in manifest_content for dep in IDENTIFIER_MOBILE_DEPENDENCIES])
+
+def __dependencies_to_remove(filters = {}):
+    is_2d = filters.get('2d', False)
+    is_3d = filters.get('3d', False)
+    is_minimal = filters.get('minimal', False)
+    is_mobile = filters.get('mobile', False)
+    if not is_2d and not is_3d:
+        is_3d = True
+
+    if is_2d and is_3d:
+        raise Exception('Cannot have both 2d and 3d filters')
+
+    to_remove = []
+    if is_2d:
+        to_remove += DEPENDENCIES_3D_ONLY
+    else:
+        to_remove += DEPENDENCIES_2D_ONLY
+
+    if is_minimal:
+        to_remove += REMOVE_ON_MINIMAL
+    if not is_mobile:
+        to_remove += DEPENDENCIES_MOBILE_ONLY
+
+    to_remove += ALWAYS_REMOVE
+
+    return set(to_remove)


### PR DESCRIPTION
Able to filter the manifest dependencies by using the options:
* `--2d`: Forces it to add 2D dependencies and exclude 3D-only dependencies
* `--3d`: Forces it to add 3D dependencies and exclude 2D-only dependencies
* `--mobile`: Forces it to add mobile-only dependencies
* `--desktop`: Forces it to exclude mobile-only dependencies
* `--slim`: Removes dependencies that usually won't be used in prototypes and
gamejam projects. (eg. localization, analytics, testing, profilling tools, etc)

Also, it refactors the code to have SetupExecutor in a separate class.